### PR TITLE
[P24-50] feat: [BE] 이사 플랜 api 구현

### DIFF
--- a/BE/src/main/java/com/example/p24zip/domain/movingPlan/controller/MovingPlanController.java
+++ b/BE/src/main/java/com/example/p24zip/domain/movingPlan/controller/MovingPlanController.java
@@ -1,0 +1,53 @@
+package com.example.p24zip.domain.movingPlan.controller;
+
+import com.example.p24zip.domain.movingPlan.dto.request.MovingPlanRequestDto;
+import com.example.p24zip.domain.movingPlan.dto.response.MovingPlanResponseDto;
+import com.example.p24zip.domain.movingPlan.repository.MovingPlanRepository;
+import com.example.p24zip.domain.movingPlan.service.MovingPlanService;
+import com.example.p24zip.domain.user.entity.User;
+import com.example.p24zip.global.response.ApiResponse;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/plans")
+public class MovingPlanController {
+
+    private final MovingPlanRepository movingPlanRepository;
+    private final MovingPlanService movingPlanService;
+
+    @PostMapping
+    public ResponseEntity<ApiResponse<MovingPlanResponseDto>> createMovingPlan(
+            @Valid @RequestBody MovingPlanRequestDto requestDto,
+            @AuthenticationPrincipal User user) {
+
+        return ResponseEntity.ok(ApiResponse.ok(
+                "CREATED",
+                "플랜이 생성되었습니다.",
+                movingPlanService.createMovingPlan(requestDto, user)
+        ));
+    }
+
+    @GetMapping
+    public ResponseEntity<ApiResponse<Map<String, List<MovingPlanResponseDto>>>> readMovingPlans(
+            @AuthenticationPrincipal User user) {
+        
+        List<MovingPlanResponseDto> movingPlans = movingPlanService.readMovingPlans(user);
+        Map<String, List<MovingPlanResponseDto>> wrappedData = new HashMap<>();
+        wrappedData.put("movingPlans", movingPlans);
+
+        return ResponseEntity.ok(ApiResponse.ok(
+                "OK",
+                "플랜 목록 조회에 성공했습니다.",
+                wrappedData
+        ));
+    }
+}

--- a/BE/src/main/java/com/example/p24zip/domain/movingPlan/controller/MovingPlanController.java
+++ b/BE/src/main/java/com/example/p24zip/domain/movingPlan/controller/MovingPlanController.java
@@ -50,4 +50,17 @@ public class MovingPlanController {
                 wrappedData
         ));
     }
+
+    @PutMapping("/{movingPlanId}")
+    public ResponseEntity<ApiResponse<MovingPlanResponseDto>> updateMovingPlan(
+            @PathVariable Long movingPlanId,
+            @RequestBody MovingPlanRequestDto requestDto,
+            @AuthenticationPrincipal User user) {
+
+        return ResponseEntity.ok(ApiResponse.ok(
+                "UPDATED",
+                "플랜 제목을 수정했습니다.",
+                movingPlanService.updateMovingPlan(movingPlanId, requestDto, user)
+        ));
+    }
 }

--- a/BE/src/main/java/com/example/p24zip/domain/movingPlan/controller/MovingPlanController.java
+++ b/BE/src/main/java/com/example/p24zip/domain/movingPlan/controller/MovingPlanController.java
@@ -60,7 +60,21 @@ public class MovingPlanController {
         return ResponseEntity.ok(ApiResponse.ok(
                 "UPDATED",
                 "플랜 제목을 수정했습니다.",
-                movingPlanService.updateMovingPlan(movingPlanId, requestDto, user)
+                movingPlanService.updateMovingPlan(movingPlanId, requestDto)
+        ));
+    }
+
+    @DeleteMapping("/{movingPlanId}")
+    public ResponseEntity<ApiResponse<Object>> deleteMovingPlan(
+            @PathVariable Long movingPlanId,
+            @AuthenticationPrincipal User user) {
+
+        movingPlanService.deleteMovingPlan(movingPlanId);
+
+        return ResponseEntity.ok(ApiResponse.ok(
+                "DELETED",
+                "플랜을 삭제했습니다.",
+                null
         ));
     }
 }

--- a/BE/src/main/java/com/example/p24zip/domain/movingPlan/dto/request/MovingPlanRequestDto.java
+++ b/BE/src/main/java/com/example/p24zip/domain/movingPlan/dto/request/MovingPlanRequestDto.java
@@ -1,0 +1,22 @@
+package com.example.p24zip.domain.movingPlan.dto.request;
+
+import com.example.p24zip.domain.movingPlan.entity.MovingPlan;
+import com.example.p24zip.domain.user.entity.User;
+import jakarta.validation.constraints.NotBlank;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class MovingPlanRequestDto {
+
+    @NotBlank
+    private String title;
+
+    public MovingPlan toEntity(User user) {
+        return MovingPlan.builder()
+                .title(this.title)
+                .user(user)
+                .build();
+    }
+}

--- a/BE/src/main/java/com/example/p24zip/domain/movingPlan/dto/response/MovingPlanResponseDto.java
+++ b/BE/src/main/java/com/example/p24zip/domain/movingPlan/dto/response/MovingPlanResponseDto.java
@@ -1,0 +1,19 @@
+package com.example.p24zip.domain.movingPlan.dto.response;
+
+import com.example.p24zip.domain.movingPlan.entity.MovingPlan;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class MovingPlanResponseDto {
+    private Long id;
+    private String title;
+
+    public static MovingPlanResponseDto from(MovingPlan movingPlan) {
+        return MovingPlanResponseDto.builder()
+                .id(movingPlan.getId())
+                .title(movingPlan.getTitle())
+                .build();
+    }
+}

--- a/BE/src/main/java/com/example/p24zip/domain/movingPlan/entity/MovingPlan.java
+++ b/BE/src/main/java/com/example/p24zip/domain/movingPlan/entity/MovingPlan.java
@@ -1,5 +1,6 @@
 package com.example.p24zip.domain.movingPlan.entity;
 
+import com.example.p24zip.domain.movingPlan.dto.request.MovingPlanRequestDto;
 import com.example.p24zip.domain.user.entity.User;
 import com.example.p24zip.global.entity.BaseTimeEntity;
 import jakarta.persistence.*;
@@ -26,5 +27,11 @@ public class MovingPlan extends BaseTimeEntity {
     public MovingPlan(String title, User user) {
         this.title = title;
         this.user = user;
+    }
+
+    public MovingPlan update(MovingPlanRequestDto requestDto) {
+        this.title = requestDto.getTitle();
+
+        return this;
     }
 }

--- a/BE/src/main/java/com/example/p24zip/domain/movingPlan/entity/MovingPlan.java
+++ b/BE/src/main/java/com/example/p24zip/domain/movingPlan/entity/MovingPlan.java
@@ -3,10 +3,7 @@ package com.example.p24zip.domain.movingPlan.entity;
 import com.example.p24zip.domain.user.entity.User;
 import com.example.p24zip.global.entity.BaseTimeEntity;
 import jakarta.persistence.*;
-import lombok.AccessLevel;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.Setter;
+import lombok.*;
 
 @Entity
 @Getter
@@ -24,4 +21,10 @@ public class MovingPlan extends BaseTimeEntity {
     @ManyToOne
     @JoinColumn(name = "user_id")
     private User user;
+
+    @Builder
+    public MovingPlan(String title, User user) {
+        this.title = title;
+        this.user = user;
+    }
 }

--- a/BE/src/main/java/com/example/p24zip/domain/movingPlan/repository/MovingPlanRepository.java
+++ b/BE/src/main/java/com/example/p24zip/domain/movingPlan/repository/MovingPlanRepository.java
@@ -1,9 +1,14 @@
 package com.example.p24zip.domain.movingPlan.repository;
 
 import com.example.p24zip.domain.movingPlan.entity.MovingPlan;
+import com.example.p24zip.domain.user.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
+
 @Repository
 public interface MovingPlanRepository extends JpaRepository<MovingPlan, Long> {
+
+    List<MovingPlan> findAllByUserOrderByCreatedAtDesc(User user);
 }

--- a/BE/src/main/java/com/example/p24zip/domain/movingPlan/service/MovingPlanService.java
+++ b/BE/src/main/java/com/example/p24zip/domain/movingPlan/service/MovingPlanService.java
@@ -2,8 +2,10 @@ package com.example.p24zip.domain.movingPlan.service;
 
 import com.example.p24zip.domain.movingPlan.dto.request.MovingPlanRequestDto;
 import com.example.p24zip.domain.movingPlan.dto.response.MovingPlanResponseDto;
+import com.example.p24zip.domain.movingPlan.entity.MovingPlan;
 import com.example.p24zip.domain.movingPlan.repository.MovingPlanRepository;
 import com.example.p24zip.domain.user.entity.User;
+import com.example.p24zip.global.exception.ResourceNotFoundException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -26,5 +28,13 @@ public class MovingPlanService {
         return movingPlanRepository.findAllByUserOrderByCreatedAtDesc(user).stream()
                 .map(MovingPlanResponseDto::from)
                 .toList();
+    }
+
+    @Transactional
+    public MovingPlanResponseDto updateMovingPlan(Long id, MovingPlanRequestDto requestDto, User user) {
+        MovingPlan movingPlan = movingPlanRepository.findById(id).orElseThrow(() -> new ResourceNotFoundException());
+        movingPlan.update(requestDto);
+
+        return MovingPlanResponseDto.from(movingPlan);
     }
 }

--- a/BE/src/main/java/com/example/p24zip/domain/movingPlan/service/MovingPlanService.java
+++ b/BE/src/main/java/com/example/p24zip/domain/movingPlan/service/MovingPlanService.java
@@ -1,0 +1,30 @@
+package com.example.p24zip.domain.movingPlan.service;
+
+import com.example.p24zip.domain.movingPlan.dto.request.MovingPlanRequestDto;
+import com.example.p24zip.domain.movingPlan.dto.response.MovingPlanResponseDto;
+import com.example.p24zip.domain.movingPlan.repository.MovingPlanRepository;
+import com.example.p24zip.domain.user.entity.User;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class MovingPlanService {
+
+    private final MovingPlanRepository movingPlanRepository;
+
+    @Transactional
+    public MovingPlanResponseDto createMovingPlan(MovingPlanRequestDto requestDto, User user) {
+        return MovingPlanResponseDto.from(movingPlanRepository.save(requestDto.toEntity(user)));
+    }
+
+    public List<MovingPlanResponseDto> readMovingPlans(User user) {
+        return movingPlanRepository.findAllByUserOrderByCreatedAtDesc(user).stream()
+                .map(MovingPlanResponseDto::from)
+                .toList();
+    }
+}

--- a/BE/src/main/java/com/example/p24zip/domain/movingPlan/service/MovingPlanService.java
+++ b/BE/src/main/java/com/example/p24zip/domain/movingPlan/service/MovingPlanService.java
@@ -31,10 +31,19 @@ public class MovingPlanService {
     }
 
     @Transactional
-    public MovingPlanResponseDto updateMovingPlan(Long id, MovingPlanRequestDto requestDto, User user) {
-        MovingPlan movingPlan = movingPlanRepository.findById(id).orElseThrow(() -> new ResourceNotFoundException());
+    public MovingPlanResponseDto updateMovingPlan(Long id, MovingPlanRequestDto requestDto) {
+        MovingPlan movingPlan = movingPlanRepository.findById(id)
+                .orElseThrow(() -> new ResourceNotFoundException());
         movingPlan.update(requestDto);
 
         return MovingPlanResponseDto.from(movingPlan);
+    }
+
+    @Transactional
+    public void deleteMovingPlan(Long id) {
+        MovingPlan movingPlan = movingPlanRepository.findById(id)
+                .orElseThrow(() -> new ResourceNotFoundException());
+
+        movingPlanRepository.delete(movingPlan);
     }
 }

--- a/BE/src/main/java/com/example/p24zip/domain/user/dto/response/ResponseDto.java
+++ b/BE/src/main/java/com/example/p24zip/domain/user/dto/response/ResponseDto.java
@@ -1,4 +1,0 @@
-package com.example.p24zip.domain.user.dto.response;
-
-public class ResponseDto {
-}


### PR DESCRIPTION
## 🔍 관련 Jira 이슈

- P24-50

## 📝 변경 사항

<!-- 이번 PR에서 작업한 내용을 명확히 기술해주세요 -->
- 이사 플랜 생성 api 구현
- 이사 플랜 목록 조회 api 구현
- 이사 플랜 이름 수정 api 구현
- 이사 플랜 삭제 api 구현


## ✅ PR 체크리스트

- [ ] 커밋 메시지에 Jira 이슈 번호 포함
- [ ] 관련 문서 업데이트 (필요한 경우)
- [ ] Jira 이슈 상태 업데이트

## 📌 참고 사항

